### PR TITLE
Have the pure-python implementation avoid wrapping __parent__.

### DIFF
--- a/src/ExtensionClass/__init__.py
+++ b/src/ExtensionClass/__init__.py
@@ -216,8 +216,8 @@ class ExtensionClass(type):
 
 def Base_getattro(self, name):
     res = object.__getattribute__(self, name)
-    # If it's a descriptor, call it.
-    if isinstance(res, Base):
+    # If it's a descriptor for something besides __parent__, call it.
+    if name != '__parent__' and isinstance(res, Base):
         descr_get = getattr(res, '__get__', None)
         if descr_get is not None:
             res = descr_get(self, type(self))

--- a/src/ExtensionClass/tests.py
+++ b/src/ExtensionClass/tests.py
@@ -844,6 +844,32 @@ def test__init__w_arg():
     <ExtensionClass.Base object at ...>
     """
 
+def test__parent__does_not_get_wrapped():
+    """
+    The issue at
+    https://github.com/zopefoundation/ExtensionClass/issues/3
+    describes how commit afb8488 made the C implementation of
+    ExtensionClass.Base not wrap __parent__ objects, but the pure
+    python version was still doing so. Let's make sure that the behaviour
+    is consistent.
+
+    >>> import ExtensionClass
+    >>> class I(ExtensionClass.Base):
+    ...
+    ...     def __init__(self, id):
+    ...         self.id = id
+    ...
+    ...     def __of__(self,o):
+    ...         return 'wrapped'
+    ...
+    ...     def __repr__(self):
+    ...         return self.id
+    ...
+    >>> x = I('a')
+    >>> x.__parent__ = I('b')
+    >>> x.__parent__
+    b
+    """
 
 from doctest import DocTestSuite
 import unittest

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
 
 [testenv]
 commands =
-    nosetests --doctest-tests
+    nosetests --where=src --with-doctest --doctest-tests
 deps =
     nose
 
@@ -18,7 +18,7 @@ setenv =
 basepython =
     python2.7
 commands =
-    nosetests --with-xunit --with-xcoverage --doctest-tests
+    nosetests --with-xunit --with-xcoverage  --with-doctest --doctest-tests --where=src
 deps =
     nose
     coverage


### PR DESCRIPTION
Fix issue #3. Test this.