### PR TITLE
fix calling `__class_init__` hook by the Python implementation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 4.1.2 (unreleased)
 ------------------
 
-- TBD
+- Fix calling of `__class_init__` hook by Python implementation.
 
 4.1.1 (2015-03-20)
 ------------------

--- a/src/ExtensionClass/__init__.py
+++ b/src/ExtensionClass/__init__.py
@@ -153,10 +153,6 @@ class ExtensionClass(type):
            any(issubclass(b, _NoInstanceDictionaryBase) for b in bases)):
             attrs['__slots__'] = []
 
-        # make sure __class_init__ is a class method
-        if '__class_init__' in attrs:
-            attrs['__class_init__'] = classmethod(attrs['__class_init__'])
-
         cls = type.__new__(cls, name, bases, attrs)
 
         # Inherit docstring
@@ -168,7 +164,10 @@ class ExtensionClass(type):
 
         # call class init method
         if hasattr(cls, '__class_init__'):
-            cls.__class_init__()
+            class_init = cls.__class_init__
+            if hasattr(class_init, '__func__'):
+                class_init = class_init.__func__
+            class_init(cls)
         return cls
 
     def __basicnew__(self):

--- a/src/ExtensionClass/tests.py
+++ b/src/ExtensionClass/tests.py
@@ -39,9 +39,9 @@ def test_mixing():
     ...              O2.inheritedAttribute('x')(a[0]))
 
     >>> class C(Base):
-    ...   def __class_init__(self):
+    ...   def __class_init__(cls):
     ...      print('class init called')
-    ...      print(self.__name__)
+    ...      print(cls.__name__)
     ...   def bar(self):
     ...      return 'bar called'
     class init called
@@ -870,6 +870,24 @@ def test__parent__does_not_get_wrapped():
     >>> x.__parent__
     b
     """
+
+def test_unbound_function_as___class_init___hook():
+    """
+    Zope patches an unbound function as a `__class_init__` hook onto `Persistent`;
+    let's make sure that gets called correctly.
+
+    >>> def InitializeClass(cls):
+    ...     print('InitializeClass called')
+    ...     print(cls.__name__)
+    >>> class A(Base):
+    ...     pass
+    >>> A.__class_init__ = InitializeClass
+    >>> class B(A):
+    ...     pass
+    InitializeClass called
+    B
+    """
+
 
 from doctest import DocTestSuite
 import unittest


### PR DESCRIPTION
Always call `__class_init__` as an unbound function, like the C implementation does,
so it works even when `__class_init__` is patched in after class creation like
Zope does to `Persistent`.

The extra check for `__func__` is because getting a function attribute in Python 3
does not turn it into a method.