### PR TITLE
Add comments and a test to clarify that Base_getattro and friends do not need to use super()

### DIFF
--- a/src/ExtensionClass/__init__.py
+++ b/src/ExtensionClass/__init__.py
@@ -213,6 +213,11 @@ class ExtensionClass(type):
         return type.__setattr__(self, name, value)
 
 
+# Base and object are always moved to the last two positions
+# in a subclasses mro, no matter how they are declared in the
+# hierarchy. This means the Base_* methods effectively don't have
+# to care or worry about using super(): it's always object.
+
 def Base_getattro(self, name):
     res = object.__getattribute__(self, name)
     # If it's a descriptor for something besides __parent__, call it.


### PR DESCRIPTION
This comes from the investigation sparked by [this comment/issue](https://github.com/zopefoundation/persistent/pull/20#issuecomment-99154946). 

Simply from looking at, e.g., `Base_getattro` it was non-obvious to me why it wasn't calling `super()`, and it made debugging more difficult that `Class.__bases__` didn't match `Class.mro()`. I also didn't see any test cases that specifically checked that behaviour, although they were implied by `test_mro`. So these comments and tests are a bit of belt-and-suspenders to help future spelunkers.

If the consensus is that they're redundant, though, I can understand that.