### PR TITLE
Reach 100% coverage and add coveralls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ parts
 .installed.cfg
 develop-eggs/
 eggs/
-nosetests.xml
-src/coverage.xml
+
+htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ matrix:
           sudo: true
 install:
     - pip install -U pip setuptools
+    - pip install -U coverage coveralls
     - pip install -U -e .[test]
 script:
-    - zope-testrunner --test-path=src
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,23 @@ language: python
 sudo: false
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
     - 3.6
     - pypy
-    - pypy3.3-5.2-alpha1
+    - pypy3
+matrix:
+    include:
+        - python: "2.7"
+          env: PURE_PYTHON=1
+        - python: "3.7"
+          dist: xenial
+          sudo: true
 install:
-    - pip install zc.buildout
-    - buildout bootstrap
-    - buildout
+    - pip install -U pip setuptools
+    - pip install -U -e .[test]
 script:
-    - bin/test -v1
+    - zope-testrunner --test-path=src
 notifications:
     email: false
-cache:
-  pip: true
-  directories:
-    - eggs/
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@ Changelog
 
 - Add support for Python 3.7.
 
+- Fix getting attributes that are data descriptors in the Python
+  implementation.
+
+- Reach and automatically maintain 100% test coverage.
+
 4.3.0 (2017-02-22)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Changelog
 
 - add Appveyor configuration to automate building Windows eggs
 
+- Add support for Python 3.7.
+
 4.3.0 (2017-02-22)
 ------------------
 
@@ -106,7 +108,7 @@ Changelog
 2.11.2 (2009-08-02)
 -------------------
 
-- Fixed 64-bit compatibility issues for Python 2.5.x / 2.6.x.  See 
+- Fixed 64-bit compatibility issues for Python 2.5.x / 2.6.x.  See
   http://www.python.org/dev/peps/pep-0353/ for details.
 
 2.11.1 (2009-02-19)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - python: 35-x64
     - python: 36
     - python: 36-x64
+    - python: 37
+    - python: 37-x64
 
 install:
   - "SET PATH=C:\\Python%PYTHON%;c:\\Python%PYTHON%\\scripts;%PATH%"

--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,10 @@ with open('CHANGES.rst') as f:
     CHANGES = f.read()
 
 # PyPy won't build the extension.
-py_impl = getattr(platform, 'python_implementation', lambda: None)
+py_impl = platform.python_implementation
 is_pypy = py_impl() == 'PyPy'
-is_pure = 'PURE_PYTHON' in os.environ
-if is_pypy or is_pure:
+
+if is_pypy:
     ext_modules = []
 else:
     ext_modules = [
@@ -71,10 +71,16 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     ext_modules=ext_modules,
     include_package_data=True,
     zip_safe=False,
+    extras_require={
+        'test': [
+            'zope.testrunner',
+        ],
+    },
 )

--- a/src/ComputedAttribute/tests.py
+++ b/src/ComputedAttribute/tests.py
@@ -94,17 +94,15 @@ class TestComputedAttribute(unittest.TestCase):
         self.assertIsInstance(x.a, ComputedAttribute)
 
     def test_compilation(self):
-        from ExtensionClass import C_EXTENSION
-        if C_EXTENSION:
+        from ExtensionClass import _IS_PYPY
+        try:
             from ComputedAttribute import _ComputedAttribute
-            self.assertTrue(hasattr(_ComputedAttribute, 'ComputedAttribute'))
+        except ImportError: # pragma: no cover
+            self.assertTrue(_IS_PYPY)
         else:
-            with self.assertRaises((AttributeError, ImportError)):
-                from ComputedAttribute import _ComputedAttribute
-
+            self.assertTrue(hasattr(_ComputedAttribute, 'ComputedAttribute'))
 
 def test_suite():
-    suite = unittest.TestSuite()
+    suite = unittest.defaultTestLoader.loadTestsFromName(__name__)
     suite.addTest(DocTestSuite())
-    suite.addTest(unittest.makeSuite(TestComputedAttribute))
     return suite

--- a/src/ExtensionClass/tests.py
+++ b/src/ExtensionClass/tests.py
@@ -985,8 +985,8 @@ class Test_add_classic_mro(unittest.TestCase):
 class TestExtensionClass(unittest.TestCase):
 
     def test_compilation(self):
-        from ExtensionClass import C_EXTENSION
-        if C_EXTENSION:
+        from ExtensionClass import _IS_PYPY
+        if not _IS_PYPY:
             from ExtensionClass import _ExtensionClass
             self.assertTrue(hasattr(_ExtensionClass, 'CAPI2'))
         else:
@@ -998,7 +998,5 @@ def test_suite():
     return unittest.TestSuite((
         DocTestSuite('ExtensionClass'),
         DocTestSuite(),
-        unittest.makeSuite(TestEffectivelyCooperativeBase),
-        unittest.makeSuite(Test_add_classic_mro),
-        unittest.makeSuite(TestExtensionClass),
+        unittest.defaultTestLoader.loadTestsFromName(__name__)
     ))

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,13 @@
 [tox]
 envlist =
-    py27,py27-pure,py34,py34-pure,py35,py35-pure,py36,py36-pure,pypy,pypy3,coverage
+    py27,py27-pure,py34,py34-pure,py35,py35-pure,py36,py36-pure,py37,pypy,pypy3,coverage
 
 [testenv]
-install_command = pip install --no-cache-dir --no-binary=:all: {opts} {packages}
+install_command = pip install {opts} {packages}
 commands =
-    zope-testrunner --test-path={envsitepackagesdir} -s ComputedAttribute -s ExtensionClass -s MethodObject
+    zope-testrunner --test-path=src
 deps =
-    zope.testrunner
-setenv =
-    PIP_NO_CACHE = 1
+     .[test]
 
 [testenv:py27-pure]
 basepython =
@@ -36,14 +34,15 @@ setenv =
     PURE_PYTHON = 1
 
 [testenv:coverage]
+usedevelop = true
 basepython =
     python2.7
 commands =
     coverage erase
-    coverage run {envbindir}/zope-testrunner --test-path={envsitepackagesdir} -s ComputedAttribute -s ExtensionClass -s MethodObject
+    coverage run -m zope.testrunner --test-path=src
     coverage report
 deps =
+    {[testenv]deps}
     coverage
-    zope.testrunner
 setenv =
     PURE_PYTHON = 1

--- a/tox.ini
+++ b/tox.ini
@@ -36,11 +36,10 @@ setenv =
 [testenv:coverage]
 usedevelop = true
 basepython =
-    python2.7
+    python3.6
 commands =
-    coverage erase
     coverage run -m zope.testrunner --test-path=src
-    coverage report
+    coverage report --fail-under=100
 deps =
     {[testenv]deps}
     coverage


### PR DESCRIPTION
This process revealed a bug in the Python implementation of Base_getattro: it didn't support data descriptors due to a typo. I fixed that.

Currently based on #20 because that's where I started the process.