### PR TITLE
Make Python implementation handle None as a value of a class attribute

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,21 @@
-Changelog
-=========
+===========
+ Changelog
+===========
 
-4.5 (unreleased)
-----------------
+4.5.0 (unreleased)
+==================
 
 - Drop support for Python 3.4.
 
 - Add support for Python 3.8.
 
+- Fix accessing ``__parent__`` when it is defined as a class attribute
+  that is ``None`` (e.g., in subclasses of
+  ``zope.conatiner.contained.Contained``). See `issue 24
+  <https://github.com/zopefoundation/ExtensionClass/issues/24>`_.
 
-4.4 (2018-10-05)
-----------------
+4.4.0 (2018-10-05)
+==================
 
 - Fail if C extensions couldn't be compiled on compatible platforms.
 
@@ -24,21 +29,21 @@ Changelog
 - Reach and automatically maintain 100% test coverage.
 
 4.3.0 (2017-02-22)
-------------------
+==================
 
 - Drop support for Python 3.3.
 
-- Remove unused C macro from `ExtensionClass.h`.
+- Remove unused C macro from ``ExtensionClass.h``.
 
 - Fix C compilation under Windows.
 
 4.2.1 (2017-02-02)
-------------------
+==================
 
 - Fix problems with computed attribute and property wrapping.
 
 4.2.0 (2017-01-18)
-------------------
+==================
 
 - Port the C extension to Python 3.
 
@@ -47,28 +52,28 @@ Changelog
 - Drop support for Python 2.6, 3.2.
 
 4.1.2 (2015-04-03)
-------------------
+==================
 
-- Fix calling of `__class_init__` hook by Python implementation.
+- Fix calling of ``__class_init__`` hook by Python implementation.
 
 4.1.1 (2015-03-20)
-------------------
+==================
 
 - Avoid wrapping ``__parent__`` in pure-Python version.  Matches
   change made to C version in afb8488.  See issue #3.
 
 4.1 (2014-12-18)
-------------------
+================
 
 - Housekeeping changes only.
 
 4.1b1 (2014-11-12)
-------------------
+==================
 
 - Added compatibility with Python 3.4.
 
 4.1a1 (2013-05-04)
-------------------
+==================
 
 - Added compatibility with Python 3.2 and 3.3 using the Python reference
   implementation.
@@ -76,29 +81,29 @@ Changelog
 - Add Python reference implementation. Used by default on PyPy.
 
 4.0 (2013-02-24)
-----------------
+================
 
 - Added trove classifiers to project metadata.
 
 4.0a1 (2011-12-13)
-------------------
+==================
 
 - Don't create wrappers when retrieving parent pointers.
 
 2.13.2 (2010-06-16)
--------------------
+===================
 
 - LP #587760: Handle tp_basicsize correctly.
 
 2.13.1 (2010-04-03)
--------------------
+===================
 
 - Removed undeclared testing dependency on zope.testing.
 
 - Removed cruft in ``pickle/pickle.c`` related to removed ``__getnewargs__``.
 
 2.13.0 (2010-02-22)
--------------------
+===================
 
 - Avoid defining ``__getnewargs__`` as not to defeat the ZODB persistent
   reference optimization. Refs https://bugs.launchpad.net/zope2/+bug/143657.
@@ -106,7 +111,7 @@ Changelog
   objects.
 
 2.12.0 (2010-02-14)
--------------------
+===================
 
 - Removed old build artifacts and some metadata cleanup.
 
@@ -114,17 +119,17 @@ Changelog
   Yoshinori K. Okuji. See https://bugs.launchpad.net/zope2/+bug/486182.
 
 2.11.3 (2009-08-02)
--------------------
+===================
 
 - Further 64-bit fixes (Python 2.4 compatibility).
 
 2.11.2 (2009-08-02)
--------------------
+===================
 
 - Fixed 64-bit compatibility issues for Python 2.5.x / 2.6.x.  See
   http://www.python.org/dev/peps/pep-0353/ for details.
 
 2.11.1 (2009-02-19)
--------------------
+===================
 
 - Initial egg release.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,9 @@
-ExtensionClass and ExtensionClass-related packages
-==================================================
+====================================================
+ ExtensionClass and ExtensionClass-related packages
+====================================================
 
 ExtensionClass
---------------
+==============
 
 This package provides a metaclass that allows classes implemented in
 extension modules to be subclassed in Python.  Unless you need
@@ -10,7 +11,7 @@ ExtensionClasses for legacy applications (e.g. Zope), you probably
 want to use Python's new-style classes (available since Python 2.2).
 
 ComputedAttribute
------------------
+=================
 
 This package provides a way to attach attributes to an
 ``ExtensionClass`` or instance that are computed by calling a
@@ -20,7 +21,7 @@ an instance and that it honours ExtensionClass semantics (which is
 useful for retaining Acquisition wrappers, for example).
 
 MethodObject
-------------
+============
 
 This package lets you attach additional "methods" to ExtensionClasses.
 These "methods" are actually implemented by subclassing the

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ else:
                   include_dirs=['src']),
     ]
 
-version = '4.5.dev0'
+version = '4.5.0.dev0'
 
 setup(
     name='ExtensionClass',


### PR DESCRIPTION
Adds a failing test case and then fixes it.

Minor refactoring to allow testing the Python and C implementations at the same time.

Fixes #24