### PR TITLE
non-cibuildwheel tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,12 +150,15 @@ jobs:
           - "3.5"
           - "pypy-2.7"
           - "pypy-3.7"
+          - "pypy-3.8"
         os: [ubuntu-20.04, macos-latest, windows-latest]
         exclude:
           - os: macos-latest
             python-version: "pypy-2.7"
           - os: macos-latest
             python-version: "pypy-3.7"
+          - os: macos-latest
+            python-version: "pypy-3.8"
           - os: macos-latest
             python-version: "3.5"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -161,6 +161,8 @@ jobs:
             python-version: "pypy-3.8"
           - os: macos-latest
             python-version: "3.5"
+          - os: windows-latest
+            python-version: "2.7"
 
     steps:
       - name: checkout
@@ -169,10 +171,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: "Install Visual C++ for Python 2.7"
-        if: runner.os == 'Windows' && ${{ matrix.python-version }} == "2.7"
-        run: |
-          choco install vcpython27 -f -y
       - name: Install ExtensionClass
         run: |
           pip install -U wheel setuptools

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,8 +104,7 @@ jobs:
             PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner -s ExtensionClass --test-path=`python -c 'import site; print(site.getsitepackages()[0])'` -v --auto-color
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_TEST_COMMAND_WINDOWS: "zope-testrunner --test-path=src"
-      - uses: actions/upload-art
-      act@v2
+      - uses: actions/upload-artifact@v2
         with:
           name: dist
           path: wheelhouse/*.whl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: dist/*.tar.*
+        path: dist/*.tar.*      
 
   wheels-ubuntu:
     name: Build on ${{ matrix.python}}ubuntu-${{ matrix.arch}}
@@ -139,6 +139,64 @@ jobs:
         with:
           name: dist
           path: wheelhouse/*.whl
+          
+  non-cibuildwheel-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - "2.7"
+          - "3.5"
+          - "pypy-2.7"
+          - "pypy-3.7"
+          - "3.6"
+        os: [ubuntu-20.04, macos-latest, windows-latest]
+        exclude:
+          - os: macos-latest
+            python-version: "pypy-2.7"
+          - os: macos-latest
+            python-version: "pypy-3.7"
+          - os: macos-latest
+            python-version: "3.5"
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install ExtensionClass
+        run: |
+          pip install -U wheel setuptools
+          # coverage has a wheel on PyPI for a future python version which is
+          # not ABI compatible with the current one, so build it from sdist:
+          pip install -U --no-binary :all: coverage
+          pip install -U 'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"'
+          # Unzip into src/ so that testrunner can find the .so files
+          # when we ask it to load tests from that directory. This
+          # might also save some build time?
+          unzip -n dist/ExtensionClass-*whl -d src
+          pip install -U -e .[test]
+      - name: Run tests with C extensions
+        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
+        run: |
+          python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+      - name: Run tests without C extensions
+        run:
+          # coverage makes PyPy run about 3x slower!
+          PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+      - name: Report Coverage
+        run: |
+          coverage combine
+          coverage report -i
+      - name: Submit to Coveralls
+        # This is a container action, which only runs on Linux.
+        if: ${{ startsWith(runner.os, 'Linux') }}
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel: true
 
   publish:
     name: Publish package to PyPI

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: dist
-        path: dist/*.tar.*      
+        path: dist/*.tar.*
 
   wheels-ubuntu:
     name: Build on ${{ matrix.python}}ubuntu-${{ matrix.arch}}
@@ -150,7 +150,6 @@ jobs:
           - "3.5"
           - "pypy-2.7"
           - "pypy-3.7"
-          - "3.6"
         os: [ubuntu-20.04, macos-latest, windows-latest]
         exclude:
           - os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -179,7 +179,6 @@ jobs:
           # Unzip into src/ so that testrunner can find the .so files
           # when we ask it to load tests from that directory. This
           # might also save some build time?
-          unzip -n dist/ExtensionClass-*whl -d src
           pip install -U -e .[test]
       - name: Run tests with C extensions
         if: ${{ !startsWith(matrix.python-version, 'pypy') }}
@@ -207,6 +206,7 @@ jobs:
       - wheels-ubuntu
       - wheels-macos
       - wheels-windows
+      - non-cibuildwheel-tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,7 +104,8 @@ jobs:
             PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner -s ExtensionClass --test-path=`python -c 'import site; print(site.getsitepackages()[0])'` -v --auto-color
           CIBW_TEST_SKIP: "*-macosx_universal2:arm64"
           CIBW_TEST_COMMAND_WINDOWS: "zope-testrunner --test-path=src"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-art
+      act@v2
         with:
           name: dist
           path: wheelhouse/*.whl
@@ -169,6 +170,10 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+      - name: "Install Visual C++ for Python 2.7"
+        if: runner.os == 'Windows' && ${{ matrix.python-version }} == "2.7"
+        run: |
+          choco install vcpython27 -f -y
       - name: Install ExtensionClass
         run: |
           pip install -U wheel setuptools
@@ -185,9 +190,11 @@ jobs:
         run: |
           python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Run tests without C extensions
+        env:
+          PURE_PYTHON: 1
         run:
           # coverage makes PyPy run about 3x slower!
-          PURE_PYTHON=1 python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
+          python -m coverage run -p -m zope.testrunner --test-path=src --auto-color --auto-progress
       - name: Report Coverage
         run: |
           coverage combine


### PR DESCRIPTION
@icemac, this PR adds 

- [x] Run tests for Python < 3.6
- [x] Run tests for PyPy and PyPy3

to your cibuildwheel PR #39 

it generally follows the pattern for testing that is currently used on this project.

for python 2.7, it does **not** test on `windows-latest` as [microsoft no longer makes that the necessary build tools available](https://community.chocolatey.org/packages/vcpython27#comment-5375502482), but for python 3.5, pypy27, pypy37, and pyp38, they are tested on windows, ubuntu, and mac os.