### PR TITLE
Update to current meta/config.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,8 @@ env:
   PIP_NO_PYTHON_VERSION_WARNING: 1
   PIP_NO_WARN_SCRIPT_LOCATION: 1
 
-  CFLAGS: -Ofast -pipe
-  CXXFLAGS: -Ofast -pipe
+  CFLAGS: -O3 -pipe
+  CXXFLAGS: -O3 -pipe
   # Uploading built wheels for releases.
   # TWINE_PASSWORD is encrypted and stored directly in the
   # github repo settings.
@@ -105,7 +105,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-rc.1"
+          - "3.11.0-rc.2"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -154,8 +154,8 @@ jobs:
           pip install -U pip
           pip install -U setuptools wheel twine cffi
 
-      - name: Build ExtensionClass (3.11.0-rc.1)
-        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
+      - name: Build ExtensionClass (3.11.0-rc.2)
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.2') }}
         run: |
           # Next, build the wheel *in place*. This helps ccache, and also lets us cache the configure
           # output (pip install uses a random temporary directory, making this difficult).
@@ -210,7 +210,7 @@ jobs:
           && startsWith(github.ref, 'refs/tags')
           && startsWith(runner.os, 'Mac')
           && !startsWith(matrix.python-version, 'pypy')
-          && !startsWith(matrix.python-version, '3.11.0-rc.1')
+          && !startsWith(matrix.python-version, '3.11.0-rc.2')
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
         run: |
@@ -232,7 +232,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-rc.1"
+          - "3.11.0-rc.2"
         os: [ubuntu-20.04, macos-latest]
         exclude:
           - os: macos-latest
@@ -273,8 +273,8 @@ jobs:
         with:
           name: ExtensionClass-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install ExtensionClass 3.11.0-rc.1
-        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.1') }}
+      - name: Install ExtensionClass 3.11.0-rc.2
+        if: ${{ startsWith(matrix.python-version, '3.11.0-rc.2') }}
         run: |
           pip install -U wheel setuptools
           # coverage has a wheel on PyPI for a future python version which is
@@ -287,7 +287,7 @@ jobs:
           unzip -n dist/ExtensionClass-*whl -d src
           pip install --pre -U -e .[test]
       - name: Install ExtensionClass
-        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.1') }}
+        if: ${{ !startsWith(matrix.python-version, '3.11.0-rc.2') }}
         run: |
           pip install -U wheel setuptools
           pip install -U coverage
@@ -379,6 +379,7 @@ jobs:
 
   manylinux:
     runs-on: ubuntu-20.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     # We use a regular Python matrix entry to share as much code as possible.
     strategy:
       matrix:

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "65835cb930ad0c63cd80bb2e74fcd02ccbf0077a"
+commit-id = "036e3ffe83ca0b92c0bac7ba0a68035a0a6fdbff"
 
 [python]
 with-appveyor = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.7 (unreleased)
 ================
 
-- Update Python 3.11 support to beta 5.
+- Update Python 3.11 support to rc2.
 
 
 4.6 (2022-01-14)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@
 
 - Update Python 3.11 support to rc2.
 
+- Disable unsafe math optimizations in C code.
+  (`#55 <https://github.com/zopefoundation/ExtensionClass/pull/55>`_)
+
 
 4.6 (2022-01-14)
 ================


### PR DESCRIPTION
No longer use `-Ofast` in `CFLAGS` as is known to break things.  See https://github.com/zopefoundation/meta/pull/155 for reference.