### PR TITLE
Add peliminary Python 3.13 support.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -152,29 +152,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0) - no Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && !startsWith(runner.os, 'Windows')
+      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U pip
-          pip install -U setuptools wheel twine
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install cffi
-      - name: Install Build Dependencies (3.13.0-alpha - 3.13.0) - on Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && startsWith(runner.os, 'Windows')
-        run: |
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          set PIP_CONSTRAINT=%cd%\cffi_constraint.txt
-          pip install cffi
-          pip install -U pip
-          pip install -U setuptools wheel twine
+          pip install -U setuptools wheel twine cffi
       - name: Install Build Dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
         run: |
@@ -220,30 +202,12 @@ jobs:
           python setup.py build_ext -i
           python setup.py bdist_wheel
 
-      - name: Install ExtensionClass and dependencies (3.13.0-alpha - 3.13.0) - no Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && !startsWith(runner.os, 'Windows')
+      - name: Install ExtensionClass and dependencies (3.13.0-alpha - 3.13.0)
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
         run: |
           # Install to collect dependencies into the (pip) cache.
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre .[test]
-      - name: Install ExtensionClass and dependencies (3.13.0-alpha - 3.13.0) - on Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && startsWith(runner.os, 'Windows')
-        run: |
-          # Install to collect dependencies into the (pip) cache.
-          # cffi will probably have no public release until a Python 3.13 beta
-          # or even RC release, see https://github.com/python-cffi/cffi/issues/23
-          echo "cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58" > cffi_constraint.txt
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          set PIP_CONSTRAINT=%cd%\cffi_constraint.txt
           pip install --pre .[test]
       - name: Install ExtensionClass and dependencies
         if: matrix.python-version != '3.13.0-alpha - 3.13.0'
@@ -364,16 +328,11 @@ jobs:
         with:
           name: ExtensionClass-${{ runner.os }}-${{ matrix.python-version }}.whl
           path: dist/
-      - name: Install ExtensionClass 3.13.0-alpha - 3.13.0 ${{ matrix.python-version }}- no Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && !startsWith(runner.os, 'Windows')
+      - name: Install ExtensionClass 3.13.0-alpha - 3.13.0 ${{ matrix.python-version }}
+        if: matrix.python-version == '3.13.0-alpha - 3.13.0'
         run: |
           pip install -U wheel setuptools
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
-          # coverage has a wheel on PyPI for a future python version which is
+          # coverage might have a wheel on PyPI for a future python version which is
           # not ABI compatible with the current one, so build it from sdist:
           pip install -U --no-binary :all: coverage
           # Unzip into src/ so that testrunner can find the .so files
@@ -382,27 +341,7 @@ jobs:
           unzip -n dist/ExtensionClass-*whl -d src
           # Use "--pre" here because dependencies with support for this future
           # Python release may only be available as pre-releases
-          PIP_CONSTRAINT=$PWD/cffi_constraint.txt pip install --pre -U -e .[test]
-      - name: Install ExtensionClass 3.13.0-alpha - 3.13.0 - on Windows
-        if: >
-          matrix.python-version == '3.13.0-alpha - 3.13.0'
-          && startsWith(runner.os, 'Windows')
-        run: |
-          pip install -U wheel setuptools
-          # cffi will probably have no public release until a beta or even RC
-          # version of Python 3.13, see https://github.com/python-cffi/cffi/issues/23
-          echo 'cffi @ git+https://github.com/python-cffi/cffi.git@954cab4f889fb019a7f90df153ee1be501495f58 ; platform_python_implementation == "CPython"' > cffi_constraint.txt
-          # coverage has a wheel on PyPI for a future python version which is
-          # not ABI compatible with the current one, so build it from sdist:
-          pip install -U --no-binary :all: coverage
-          # Unzip into src/ so that testrunner can find the .so files
-          # when we ask it to load tests from that directory. This
-          # might also save some build time?
-          unzip -n dist/ExtensionClass-*whl -d src
-          # Use "--pre" here because dependencies with support for this future
-          # Python release may only be available as pre-releases
-          set PIP_CONSTRAINT=%cd%\cffi_constraint.txt
-          pip install --pre -U -e .[test]
+          txt pip install --pre -U -e .[test]
       - name: Install ExtensionClass
         if: ${{ !startsWith(matrix.python-version, '3.13.0-alpha - 3.13.0') }}
         run: |

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/c-code
 [meta]
 template = "c-code"
-commit-id = "32bb1a75"
+commit-id = "8daa034c"
 
 [python]
 with-windows = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,8 @@
 
 - Build Windows wheels on GHA.
 
+- Add preliminary support for Python 3.13.
+
 
 5.1 (2023-10-05)
 ================


### PR DESCRIPTION
It requires:

- [ ] ~a cffi release~ we do not depend on `cffi` here.